### PR TITLE
fix: :fire: Remove Google Analytics tag script. It is replaced by the Google Tag Manager scripts

### DIFF
--- a/lib/functions/gtm.php
+++ b/lib/functions/gtm.php
@@ -13,24 +13,7 @@
  */
 
 add_action('wp_head', 'rcid_google_tag_manager_head' );
-add_action('wp_body_open', 'rcid_google_analytics' );
 add_action('wp_body_open', 'rcid_google_tag_manager_body' );
-
-
-function rcid_google_analytics()
-{
-    ?>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BLMEKZLMMC"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-BLMEKZLMMC');
-    </script>
-    <?php
-}
 
 function rcid_google_tag_manager_head()
 {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/Herm71/rcid-core-functionality.git
  * GitHub Plugin URI: https://github.com/Herm71/rcid-core-functionality
  * Description: Contains custom functionality. Theme independent.
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Jason Chafin
  * Author URI: https://github.com/Herm71
  * License: GPL2


### PR DESCRIPTION
Adding GTM made the GA4 tag script redundant. It was removed.